### PR TITLE
Proposal for adding a dynamic simulation mode into the dVRK

### DIFF
--- a/core/components/code/mtsRobot1394.cpp
+++ b/core/components/code/mtsRobot1394.cpp
@@ -412,6 +412,13 @@ void mtsRobot1394::CalibrateEncoderOffsetsFromPotentiometers(const int & numberO
 
 bool mtsRobot1394::CheckConfiguration(void)
 {
+    if (mHwSimulation)
+    {
+        CMN_LOG_CLASS_INIT_WARNING << "CheckConfiguration: skipping configuration check for simulated hardware for arm: "
+                                   << this->Name() << std::endl;
+        return true;
+    }
+
     // current calibration
     if ((m_configuration.hardware_version != osa1394::dRA1)
         && (NumberOfActuators() > 2)) {
@@ -1062,7 +1069,9 @@ void mtsRobot1394::CheckState(void)
             if (*enabled) {
                 actual_limit = *limit;
             } else {
-                if (m_calibration_mode || !mPowerEnable) {
+                if(mHwSimulation){
+                    actual_limit = std::numeric_limits<double>::max(); // no limit in hw simulation when amp is disabled
+                } else if (m_calibration_mode || !mPowerEnable) {
                     actual_limit = 0.2; // noise + poor calibration
                 } else {
                     actual_limit = 0.1; // 100 mA for noise in a2d

--- a/core/components/code/mtsRobotIO1394.cpp
+++ b/core/components/code/mtsRobotIO1394.cpp
@@ -178,6 +178,9 @@ void mtsRobotIO1394::Init(const std::string & port)
         exit(EXIT_FAILURE);
     }
 
+    // store if the port is simulated hardware
+    m_is_hw_simulated = (m_port->GetPortType() == BasePort::PORT_SIMULATION);
+
     mtsInterfaceProvided * mainInterface = AddInterfaceProvided("MainInterface");
     if (mainInterface) {
         mainInterface->AddCommandRead(&mtsRobotIO1394::GetNumberOfBoards, this, "GetNumberOfBoards");
@@ -304,6 +307,7 @@ void mtsRobotIO1394::Configure(const std::string & filename)
     for (const auto & configRobot : config.robots) {
         // Create a new robot
         mtsRobot1394 * robot = new mtsRobot1394(*this);
+        robot->SetHwSimulation(m_is_hw_simulated);
         robot->set_calibration_mode(m_calibration_mode);
         robot->Configure(configRobot);
         // Check the configuration if needed

--- a/core/components/include/sawRobotIO1394/mtsRobot1394.h
+++ b/core/components/include/sawRobotIO1394/mtsRobot1394.h
@@ -59,6 +59,10 @@ namespace sawRobotIO1394 {
         void LoadPotentiometerLookupTable(void);
         void Configure(const osaRobot1394Configuration & config);
 
+        void SetHwSimulation(const bool & hwSimulation){
+            mHwSimulation = hwSimulation;
+        }
+
         bool SetupStateTables(const size_t stateTableSize,
                               mtsStateTable * & stateTableRead,
                               mtsStateTable * & stateTableWrite);
@@ -399,6 +403,9 @@ namespace sawRobotIO1394 {
 
     public:
         mtsInterfaceProvided * mInterface;
+
+    private:
+        bool mHwSimulation = false;
     };
 
 } // namespace sawRobotIO1394

--- a/core/components/include/sawRobotIO1394/mtsRobotIO1394.h
+++ b/core/components/include/sawRobotIO1394/mtsRobotIO1394.h
@@ -41,6 +41,7 @@ protected:
     std::ostream * m_message_stream = nullptr; // Stream provided to the low level boards for messages, redirected to cmnLogger
 
     BasePort * m_port = nullptr;
+    bool m_is_hw_simulated = false;
 
     double m_watchdog_period = sawRobotIO1394::WatchdogTimeout; // prefered watchdog period for all boards
     bool m_skip_configuration_check = false;
@@ -107,6 +108,8 @@ public:
     void GetNumberOfRobots(size_t & placeHolder) const;
     sawRobotIO1394::mtsRobot1394 * Robot(const size_t index);
     const sawRobotIO1394::mtsRobot1394 * Robot(const size_t index) const;
+
+    bool IsHardwareSimulated(void) { return m_is_hw_simulated; }
 
     static std::string DefaultPort(void);
     void close_all_relays(void);


### PR DESCRIPTION
Hello @adeguet1,

This pull request is part of a larger project aimed at adding a hardware simulation mode to the dVRK. In particular, here, we are adding a flag based on the IO port type (I have added a new port type in the PortFactory class) to identify if the hardware connection port is a simulation port. The flag is then passed to the actual robot class, where it is used to disable both the actuation limit checker and the calibration file checker.

See [https://github.com/jhu-cisst/mechatronics-software/pull/38](https://github.com/jhu-cisst/mechatronics-software/pull/38)
See [https://github.com/jhu-saw/sawRobotIO1394/pull/17](https://github.com/jhu-saw/sawRobotIO1394/pull/17)
See [https://github.com/jhu-dvrk/sawIntuitiveResearchKit/pull/240](https://github.com/jhu-dvrk/sawIntuitiveResearchKit/pull/240)